### PR TITLE
Highlight operators in C++

### DIFF
--- a/index.less
+++ b/index.less
@@ -7,6 +7,7 @@
 @import 'language';
 
 @import 'languages/c';
+@import 'languages/cpp';
 @import 'languages/cs';
 @import 'languages/css';
 @import 'languages/gfm';

--- a/styles/languages/cpp.less
+++ b/styles/languages/cpp.less
@@ -1,0 +1,5 @@
+.source.cpp {
+  .keyword.operator {
+    color: @hue-3;
+  }
+}


### PR DESCRIPTION
Backport of https://github.com/atom/one-dark-syntax/pull/78.
